### PR TITLE
Add S3 bucket and CloudFront distribution for EOH site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,9 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+#terraform files
+.terraform/
+terraform.tfstate
+terraform.tfstate.backup
+*.tfvars

--- a/aws_infrastructure/.terraform.lock.hcl
+++ b/aws_infrastructure/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "tofu init".
+# Manual edits may be lost in future updates.
+
+provider "registry.opentofu.org/hashicorp/aws" {
+  version = "6.34.0"
+  hashes = [
+    "h1:IHJBU5VslyZTGAvHzlwGom+b2RKpNkVVAu7NhrQ/6pY=",
+    "zh:002ed5e547aeadc331d5215ededa4f1029fcf88bb673a32e1d975b76c78fba4e",
+    "zh:02b407cbf61a58466f9e0cc63706fabe64f4d8ffadf42f99079ca38f20406f93",
+    "zh:03723d882dd5c21eaba72e598dcf39b0c0a417c681a974e538ae0f289f619cfc",
+    "zh:05f68ad111719eef2efcade5d3802f1d09f14d43a20a90fa46527f6fb1f470c1",
+    "zh:159e67f6e18cd9bff5775731a3c0c1bb5ad3980bfecc63976655e8e19fe9af82",
+    "zh:199335ea73120406ea3809cb8de641d17f834ee3746638b07fb3215fdadf3fa3",
+    "zh:4ed73cc45666283cc6898e44112a1807c1319a88c44fdae482f8c02df1bc6eea",
+    "zh:7d5459ef4aad511b238b5937ef50f30c7c6f8da87da6a601cbf3524623bc19ae",
+    "zh:812428b0c571b1c02d57f34cd044c19bafa665f0d5e809d016df970819e28565",
+    "zh:8cb416b2cea90a05840843a5dadaa59de5b5f1cd102c06fab03fde05d86055b3",
+    "zh:977d102afd5000db41f17d2e55750e0316e2f87d5330aff9e3b8b3c888ff6cf8",
+    "zh:a80ba2e4baa94cb565584fb7def269cfd130d3f64129e7733f09208c82a981bc",
+    "zh:e5a3dd778fbcf16c97eb4437acf13fc41cad46cf783330db1c20f5c9d0ec7cf4",
+    "zh:f0c74e5276987255dbe77f8077a388d2ece42212a9c24da9196f01f7c420cc14",
+    "zh:fec66f0e1ca3f6ae5c838b32de72b9ae0fa3964d8786b9f9714a9a6962fa2e7a",
+  ]
+}

--- a/aws_infrastructure/main.tf
+++ b/aws_infrastructure/main.tf
@@ -1,0 +1,86 @@
+
+terraform {
+    required_providers {
+        aws = {
+            source = "hashicorp/aws"
+        }
+    }
+}
+
+provider "aws" {
+    region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "eoh_bucket" {
+    bucket = "eoh.built-illinois.org"
+}
+
+resource "aws_cloudfront_origin_access_control" "eoh_oac" {
+    name = "eoh_oac"
+    origin_access_control_origin_type = "s3"
+    signing_behavior = "always"
+    signing_protocol = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "eoh_distribution" {
+  enabled             = true
+  default_root_object = "index.html"
+
+  origin {
+    domain_name              = aws_s3_bucket.eoh_bucket.bucket_regional_domain_name
+    origin_id                = "S3Origin"
+    origin_access_control_id = aws_cloudfront_origin_access_control.eoh_oac.id
+  }
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "S3Origin"
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+  custom_error_response {
+    error_code         = 403
+    response_code      = 200
+    response_page_path = "/index.html"
+  }
+}
+
+resource "aws_s3_bucket_policy" "eoh_policy" {
+    bucket = aws_s3_bucket.eoh_bucket.id
+    policy = data.aws_iam_policy_document.eoh_policy_document.json
+}
+
+data "aws_iam_policy_document" "eoh_policy_document" {
+    statement {
+      actions = ["s3:GetObject"]
+      resources = ["${aws_s3_bucket.eoh_bucket.arn}/*"]
+
+      principals {
+        type = "Service"
+        identifiers = ["cloudfront.amazonaws.com"]
+      }
+
+      condition {
+        test = "StringEquals"
+        variable = "AWS:SourceArn"
+        values = [aws_cloudfront_distribution.eoh_distribution.arn]
+      }
+    }
+}


### PR DESCRIPTION
## Summary
Set up core AWS infrastructure for hosting the EOH site at eoh.built-illinois.org.

## Changes
- S3 bucket (`eoh.built-illinois.org`) for static site hosting
- CloudFront distribution with HTTPS redirect and `index.html` as default root object
- Origin Access Control (OAC) using SigV4 signing so the bucket isn't publicly accessible
- S3 bucket policy scoped to only allow `GetObject` requests from the CloudFront distribution
- Custom error response mapping 403 errors to `/index.html` with a 200 status code to support client-side routing in the React app

## Note
All resources are currently defined in a single `main.tf` file. In the future, this should be refactored to follow Terraform best practices by splitting into separate files (`providers.tf`, `outputs.tf`, `variables.tf`, etc.) for better organization and maintainability.